### PR TITLE
Correct required CMake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.6)
 
 PROJECT(liboccellml Fortran CXX )
 


### PR DESCRIPTION
hpc3 has CMake 2.6 installed so people have been having to compile their own CMake to get 2.8, but features from 2.8 aren't actually used and 2.6 works correctly.

@nickerso has said this should be fine.
