### PR TITLE
Use csim

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,19 +11,18 @@ option(CELLML_USE_CSIM "${PROJECT_NAME} - Use CSim to handle CellML models." ON)
 
 # This is our own package
 if(CELLML_USE_CSIM)
-    find_package(CSim ${CSim_VERSION} REQUIRED)
-    add_definitions(-DCELLML_USE_CSIM)
+    find_package(CSim ${CSIM_VERSION} CONFIG REQUIRED)
 else()
     find_package(LIBCELLML ${LIBCELLML_VERSION} REQUIRED) # gives ccgs
     find_package(LibXml2 ${LIBXML2_VERSION} REQUIRED)
-endif(CELLML_USE_CSIM)
+endif()
 
 # Use common include directory
 set(LIBCELLML_INCLUDE_DEST include)
 
 # Probably better to not do this as it probably overrides and external value?
 if( MSVC )
-    add_definitions(-D_CRT_SECURE_NO_WARNINGS -DWINVER=0x0600 )    
+    add_definitions(-D_CRT_SECURE_NO_WARNINGS -DWINVER=0x0600)
 elseif(NOT MINGW)
     add_definitions(-DDYNAMIC_COMPILE)
 endif()
@@ -39,12 +38,15 @@ SET(cellml-api-src
   src/ccgs_required_functions.cpp
 )
 
-# need to handle the fortran code specially?
-
 add_library(cellml_api ${cellml-api-src})
-target_link_libraries(cellml_api PUBLIC ccgs xml2)
+if (CELLML_USE_CSIM)
+    target_compile_definitions(cellml_api PUBLIC $<BUILD_INTERFACE:CELLML_USE_CSIM>)
+    target_link_libraries(cellml_api PUBLIC csim)
+else()
+    target_link_libraries(cellml_api PUBLIC ccgs xml2)
+endif()
 add_library(cellml_model_definition src/cellml_model_definition.f90)
-target_link_libraries(cellml_model_definition LINK_INTERFACE_LIBRARIES cellml_api)
+target_link_libraries(cellml_model_definition INTERFACE cellml_api)
 
 # Testing executables
 if(BUILD_TESTS)
@@ -81,9 +83,18 @@ WRITE_BASIC_PACKAGE_VERSION_FILE(${CMAKE_CURRENT_BINARY_DIR}/cellml-config-versi
     COMPATIBILITY AnyNewerVersion)
 file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/cellml-config-dependencies.cmake 
     "include(CMakeFindDependencyMacro)\r\n"
-	"set(${PROJECT_NAME}_IMPORT_PREFIX \${_IMPORT_PREFIX})\r\n"
-    "find_dependency(LIBCELLML ${LIBCELLML_VERSION})\r\n"
-    "find_dependency(LibXml2 ${LIBXML2_VERSION})\r\n"
+	"set(${PROJECT_NAME}_IMPORT_PREFIX \${_IMPORT_PREFIX})\r\n")
+if (CELLML_USE_CSIM)
+    file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/cellml-config-dependencies.cmake	
+        "find_dependency(CSim ${CSIM_VERSION})\r\n"
+    )
+else()
+    file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/cellml-config-dependencies.cmake	
+        "find_dependency(LIBCELLML ${LIBCELLML_VERSION})\r\n"
+        "find_dependency(LibXml2 ${LIBXML2_VERSION})\r\n"
+    )
+endif()
+file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/cellml-config-dependencies.cmake
     "set(_IMPORT_PREFIX \${${PROJECT_NAME}_IMPORT_PREFIX})"
 )
 install(FILES 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,9 +27,9 @@ elseif(NOT MINGW)
     add_definitions(-DDYNAMIC_COMPILE)
 endif()
 include(CheckCXXCompilerFlag)
-CHECK_CXX_COMPILER_FLAG("-Wall -Werror" W_FLAGS)
+CHECK_CXX_COMPILER_FLAG("-Wall" W_FLAGS)
 if (W_FLAGS)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Werror")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
 endif()
 
 SET(cellml-api-src

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,13 +1,22 @@
 cmake_minimum_required(VERSION 3.1)
-PROJECT(cellml-api VERSION 1.0 LANGUAGES Fortran CXX)
+PROJECT(cellml-api VERSION 1.1 LANGUAGES Fortran CXX)
 
 option(BUILD_TESTS "${PROJECT_NAME} - Build tests" ON)
 option(PACKAGE_CONFIG_DIR "Directory for package config files (relative to CMAKE_INSTALL_PREFIX)" "lib/cmake")
 set(CMAKE_Fortran_MODULE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/fortran)
 
+# Is this the best place for this?
+# FIXME: Need to get this to work with DYNAMIC_COMPILE
+option(CELLML_USE_CSIM "${PROJECT_NAME} - Use CSim to handle CellML models." ON)
+
 # This is our own package
-find_package(LIBCELLML ${LIBCELLML_VERSION} REQUIRED) # gives ccgs
-find_package(LibXml2 ${LIBXML2_VERSION} REQUIRED)
+if(CELLML_USE_CSIM)
+    find_package(CSim ${CSim_VERSION} REQUIRED)
+    add_definitions(-DCELLML_USE_CSIM)
+else()
+    find_package(LIBCELLML ${LIBCELLML_VERSION} REQUIRED) # gives ccgs
+    find_package(LibXml2 ${LIBXML2_VERSION} REQUIRED)
+endif(CELLML_USE_CSIM)
 
 # Use common include directory
 set(LIBCELLML_INCLUDE_DEST include)

--- a/src/CellMLModelDefinition.hpp
+++ b/src/CellMLModelDefinition.hpp
@@ -183,7 +183,6 @@ class CellMLModelDefinition
 #endif
 
   bool mSaveTempFiles;
-  void* mHandle;
   std::map<std::pair<int,int>, double> mInitialValues;
   std::map<std::string, int> mVariableTypes;
   std::map<std::string, int> mVariableIndices;
@@ -192,6 +191,7 @@ class CellMLModelDefinition
  public:
   void* mModel;
 #ifndef CELLML_USE_CSIM
+  void* mHandle;
   void* mCodeInformation;
   void* mAnnotations;
   void* mCevas;

--- a/src/CellMLModelDefinition.hpp
+++ b/src/CellMLModelDefinition.hpp
@@ -150,6 +150,7 @@ class CellMLModelDefinition
     double* WANTED,double* KNOWN);
 
  private:
+#ifndef CELLML_USE_CSIM
   /**
    * Generate C code for the given CellML model.
    * @param model The CellML model for which to generate C code.
@@ -158,9 +159,11 @@ class CellMLModelDefinition
    * @return The generated code, if successful; and empty string otherwise.
    */
   std::wstring getModelAsCCode(void* model,void* cevas,void* annotations);
+#endif
   int flagVariable(const char* name, int type,
                    std::vector<iface::cellml_services::VariableEvaluationType> vets,int& count, int& specificCount);
   std::string mURL;
+#ifndef CELLML_USE_CSIM
   std::string mTmpDirName;
   bool mTmpDirExists;
   std::string mCodeFileName;
@@ -168,9 +171,10 @@ class CellMLModelDefinition
   std::string mDsoFileName;
   bool mDsoFileExists;
   std::string mCompileCommand;
+  bool mInstantiated;
+#endif
   bool mSaveTempFiles;
   void* mHandle;
-  bool mInstantiated;
   std::map<std::pair<int,int>, double> mInitialValues;
   std::map<std::string, int> mVariableTypes;
   std::map<std::string, int> mVariableIndices;
@@ -178,9 +182,11 @@ class CellMLModelDefinition
   // need to access these?
  public:
   void* mModel;
+#ifndef CELLML_USE_CSIM
   void* mCodeInformation;
   void* mAnnotations;
   void* mCevas;
+#endif
   int mNumberOfWantedVariables;
   int mNumberOfKnownVariables;
   int mNumberOfIndependentVariables;

--- a/src/CellMLModelDefinition.hpp
+++ b/src/CellMLModelDefinition.hpp
@@ -5,6 +5,10 @@
 #include <vector>
 #include <IfaceCCGS.hxx>
 
+#ifdef CELLML_USE_CSIM
+#include "csim/model.h"
+#endif
+
 /**
  * The primary object used to define a CellML model for use in openCMISS.
  *
@@ -95,6 +99,7 @@ class CellMLModelDefinition
    */
   int instantiate();
 
+#ifndef CELLML_USE_CSIM
   /**
    * Set the compile command to use to compile the generated code into a dynamic shared object.
    * @param command The compile command.
@@ -111,6 +116,7 @@ class CellMLModelDefinition
   {
     return mCompileCommand;
   }
+#endif
 
   /**
    * Set the save temporary files flag.
@@ -129,14 +135,12 @@ class CellMLModelDefinition
     return mSaveTempFiles;
   }
 
+
   /**
    * Check model instantiation.
    * @return True if the model is instantiated; false otherwise.
    */
-  bool instantiated()
-  {
-    return mInstantiated;
-  }
+  bool instantiated();
 
   int32_t nBound;
   int32_t nRates;
@@ -160,10 +164,14 @@ class CellMLModelDefinition
    */
   std::wstring getModelAsCCode(void* model,void* cevas,void* annotations);
 #endif
+
   int flagVariable(const char* name, int type,
                    std::vector<iface::cellml_services::VariableEvaluationType> vets,int& count, int& specificCount);
   std::string mURL;
-#ifndef CELLML_USE_CSIM
+
+#ifdef CELLML_USE_CSIM
+  csim::Model* model;
+#else
   std::string mTmpDirName;
   bool mTmpDirExists;
   std::string mCodeFileName;
@@ -173,6 +181,7 @@ class CellMLModelDefinition
   std::string mCompileCommand;
   bool mInstantiated;
 #endif
+
   bool mSaveTempFiles;
   void* mHandle;
   std::map<std::pair<int,int>, double> mInitialValues;

--- a/src/CellMLModelDefinition.hpp
+++ b/src/CellMLModelDefinition.hpp
@@ -147,14 +147,24 @@ class CellMLModelDefinition
   int32_t nAlgebraic;
   int32_t nConstants;
 
+  inline void callModelFunction(double VOI,double* STATES,double* RATES,
+                                double* WANTED,double* KNOWN)
+  {
+#ifdef CELLML_USE_CSIM
+      mModelFunction(VOI, STATES, RATES, WANTED, KNOWN);
+#else
+      rhsRoutine(VOI, STATES, RATES, WANTED, KNOWN);
+#endif
+  }
+
+ private:
+#ifndef CELLML_USE_CSIM
   // loaded from the generated and compiled DSO
   /* Compute the RHS of the system of the ODE system
    */
   void (*rhsRoutine)(double VOI,double* STATES,double* RATES,
     double* WANTED,double* KNOWN);
 
- private:
-#ifndef CELLML_USE_CSIM
   /**
    * Generate C code for the given CellML model.
    * @param model The CellML model for which to generate C code.
@@ -171,6 +181,9 @@ class CellMLModelDefinition
 
 #ifdef CELLML_USE_CSIM
   csim::Model* model;
+  csim::InitialiseFunction mInitialiseFunction;
+  csim::ModelFunction mModelFunction;
+  std::vector<double> mInitStates, mInitWanted, mInitKnown;
 #else
   std::string mTmpDirName;
   bool mTmpDirExists;

--- a/src/CellMLModelDefinitionF.cpp
+++ b/src/CellMLModelDefinitionF.cpp
@@ -265,7 +265,7 @@ void cellml_model_definition_call_rhs_routine_f(void* _ptr,
 {
   // no error checks to optimise?
   CellMLModelDefinition* def = (CellMLModelDefinition*)_ptr;
-  def->rhsRoutine(voi,states,rates,wanted,known);
+  def->callModelFunction(voi,states,rates,wanted,known);
 }
 
 static char* getAbsoluteURI(const char* uri)


### PR DESCRIPTION
Work to add option for using CSim instead of the existing "generate code and compile with GCC" option. Relies on new LLVM and Clang and CSim updates. See also csim@3a9ad8dcd83e6bc5ffc45c580e099851df4d9441
