### PR TITLE
the initializition of the variable mSaveTempFiles should be done always.

### DIFF
--- a/src/CellMLModelDefinition.cpp
+++ b/src/CellMLModelDefinition.cpp
@@ -125,12 +125,12 @@ CellMLModelDefinition::CellMLModelDefinition(const char* url) :
   mTmpDirExists = false;
   mCodeFileExists = false;
   mDsoFileExists = false;
-  mSaveTempFiles = false;
   mInstantiated = false;
   mCodeInformation = NULL;
   mAnnotations = NULL;
   mCevas = NULL;
 #endif
+  mSaveTempFiles = false;
   nBound = -1;
   nRates = -1;
   nAlgebraic = -1;


### PR DESCRIPTION
when ported to the os openEuler/arm64, I find that, the value of the member variable mSaveTempFiles is not false initially, this is a problem. the Root cause is that it is uninitialized , so theoretically, its value may be a random in memory.